### PR TITLE
learn `--source`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+tmp/

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -17,6 +17,12 @@ module.exports = yeoman.generators.Base.extend({
       type: 'String',
       defaults: './'
     });
+
+    this.option('source', {
+      desc: 'source template for .eslintrc',
+      type: 'String',
+      defaults: this.templatePath('eslintrc')
+    });
   },
 
   initializing: function () {
@@ -28,7 +34,7 @@ module.exports = yeoman.generators.Base.extend({
   writing: {
     app: function () {
       this.fs.copy(
-        this.templatePath('eslintrc'),
+        path.resolve(this.options.source),
         this.destinationPath(this.options.destination, '.eslintrc')
       );
     }

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -1,13 +1,15 @@
 'use strict';
 
-var path = require('path');
 var assert = require('yeoman-generator').assert;
+var fs = require('fs');
 var helpers = require('yeoman-generator').test;
+var path = require('path');
+var appDir = path.join(__dirname, '../generators/app');
 
 suite('eslintrc:app', function () {
   suite('default behavior', function () {
     suiteSetup(function (done) {
-      helpers.run(path.join(__dirname, '../generators/app'))
+      helpers.run(appDir)
         .on('end', done);
     });
 
@@ -20,7 +22,7 @@ suite('eslintrc:app', function () {
 
   suite('--destination=foo/bar', function () {
     suiteSetup(function (done) {
-      helpers.run(path.join(__dirname, '../generators/app'))
+      helpers.run(appDir)
         .withOptions({
           destination: 'foo/bar'
         })
@@ -31,6 +33,30 @@ suite('eslintrc:app', function () {
       assert.file([
         './foo/bar/.eslintrc'
       ]);
+    });
+  });
+
+  suite('--source=foo/bar', function () {
+    var sourceText = '{ "rules": {} }';
+
+    suiteSetup(function (done) {
+      helpers.run(appDir)
+        .inDir(path.join(appDir, '../../tmp'), function (dir) {
+          fs.mkdirSync('foo');
+          fs.writeFileSync('foo/bar', sourceText);
+        })
+        .withOptions({
+          source: 'foo/bar'
+        })
+        .on('end', done);
+    });
+
+    test('writes foo/bar as .eslintrc', function () {
+      assert.file([
+        './.eslintrc'
+      ]);
+
+      assert.fileContent('./.eslintrc', sourceText);
     });
   });
 });


### PR DESCRIPTION
To use an existing file as the new `.eslintrc`, pass an absolute path or a path
relative to the current working directory via `--source`.
